### PR TITLE
Fixed Windows default spinner and prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,9 +39,12 @@ class Spinnies {
     if (!options.text) options.text = name;
     const spinnerProperties = {
       ...colorOptions(this.options),
+      succeedPrefix: this.options.succeedPrefix,
+      failPrefix: this.options.failPrefix,
       status: 'spinning',
       ...purgeSpinnerOptions(options),
     };
+
     this.spinners[name] = spinnerProperties;
     this.updateSpinnerState();
 
@@ -127,7 +130,7 @@ class Spinnies {
     const hasActiveSpinners = this.hasActiveSpinners();
     Object
       .values(this.spinners)
-      .map(({ text, status, color, spinnerColor, succeedColor, failColor }) => {
+      .map(({ text, status, color, spinnerColor, succeedColor, failColor, succeedPrefix, failPrefix }) => {
         let line;
         let prefixLength = 2;
         if (status === 'spinning') {
@@ -137,9 +140,9 @@ class Spinnies {
         } else {
           if (hasActiveSpinners) text = breakText(text, prefixLength);
           if (status === 'succeed') {
-            line = `${chalk.green('✓')} ${chalk[succeedColor](text)}`;
+            line = `${chalk.green(succeedPrefix)} ${chalk[succeedColor](text)}`;
           } else if (status === 'fail') {
-            line = `${chalk.red('✖')} ${chalk[failColor](text)}`;
+            line = `${chalk.red(failPrefix)} ${chalk[failColor](text)}`;
           } else {
             line = `- ${chalk[color](text)}`;
           }

--- a/index.js
+++ b/index.js
@@ -140,8 +140,10 @@ class Spinnies {
         } else {
           if (hasActiveSpinners) text = breakText(text, prefixLength);
           if (status === 'succeed') {
+            prefixLength = succeedPrefix.length + 1;
             line = `${chalk.green(succeedPrefix)} ${chalk[succeedColor](text)}`;
           } else if (status === 'fail') {
+            prefixLength = failPrefix.length + 1;
             line = `${chalk.red(failPrefix)} ${chalk[failColor](text)}`;
           } else {
             line = `- ${chalk[color](text)}`;

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const readline = require('readline');
-const { dots } = require('./spinners');
+const { dashes, dots } = require('./spinners');
 
 const VALID_STATUSES = ['succeed', 'fail', 'spinning', 'non-spinnable', 'stopped'];
 const VALID_COLORS = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'gray', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', 'cyanBright', 'whiteBright'];
@@ -18,18 +18,21 @@ function purgeSpinnerOptions(options) {
 }
 
 function purgeSpinnersOptions({ spinner, disableSpins, ...others }) {
+  const {succeedPrefix, failPrefix} = others;
   const colors = colorOptions(others);
+  const prefixes = prefixOptions(others);
   const disableSpinsOption = typeof disableSpins === 'boolean' ? { disableSpins } : {};
   spinner = turnToValidSpinner(spinner);
 
-  return { ...colors, ...disableSpinsOption, spinner }
+  return { ...colors, ...prefixes, ...disableSpinsOption, spinner }
 }
 
 function turnToValidSpinner(spinner = {}) {
-  if (!typeof spinner === 'object') return dots;
+  const platformSpinner = process.platform === 'win32' ? dashes : dots;
+  if (!typeof spinner === 'object') return platformSpinner;
   let { interval, frames } = spinner;
-  if (!Array.isArray(frames) || frames.length < 1) frames = dots.frames;
-  if (typeof interval !== 'number') interval = dots.interval;
+  if (!Array.isArray(frames) || frames.length < 1) frames = platformSpinner.frames;
+  if (typeof interval !== 'number') interval = platformSpinner.interval;
 
   return { interval, frames };
 }
@@ -41,6 +44,13 @@ function colorOptions({ color, succeedColor, failColor, spinnerColor }) {
   });
 
   return colors;
+}
+
+function prefixOptions({ succeedPrefix, failPrefix }) {
+  succeedPrefix = succeedPrefix ? succeedPrefix : (process.platform === 'win32' ? '√' : '✓');
+  failPrefix = failPrefix ? failPrefix : (process.platform === 'win32' ?  '×' : '✖');
+
+  return {succeedPrefix, failPrefix};
 }
 
 function breakText(text, prefixLength) {

--- a/utils.js
+++ b/utils.js
@@ -18,7 +18,6 @@ function purgeSpinnerOptions(options) {
 }
 
 function purgeSpinnersOptions({ spinner, disableSpins, ...others }) {
-  const {succeedPrefix, failPrefix} = others;
   const colors = colorOptions(others);
   const prefixes = prefixOptions(others);
   const disableSpinsOption = typeof disableSpins === 'boolean' ? { disableSpins } : {};
@@ -50,7 +49,7 @@ function prefixOptions({ succeedPrefix, failPrefix }) {
   succeedPrefix = succeedPrefix ? succeedPrefix : (process.platform === 'win32' ? '√' : '✓');
   failPrefix = failPrefix ? failPrefix : (process.platform === 'win32' ?  '×' : '✖');
 
-  return {succeedPrefix, failPrefix};
+  return { succeedPrefix, failPrefix };
 }
 
 function breakText(text, prefixLength) {


### PR DESCRIPTION
Related to https://github.com/jcarpanelli/spinnies/issues/6.

On Windows the default spinner was never set to "dashes", and was always set to "dots". I assume this is a bug as there's a check for the system type and it tries to set the spinner to "dashes", but it gets overwritten. This has been fixed. Also the default command line cannot handle the current characters used for success and fail prefixes, these have been updated to check the system type (using some "close enough" characters for Windows) and allows you to set custom prefixes if needed.