### PR TITLE
Use dots animation in certain Windows shells that support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ Parameters
   - **spinnerColor** - `string`: Any valid [chalk color](https://github.com/chalk/chalk#colors). The default value is `greenBright`.
   - **succeedPrefix** - `string`: The default value is ✓.
   - **failPrefix**- `string`: The default value is ✖.
-  - **spinner**- `object`: 
+  - **spinner**- `object`:
     - **interval** - `number`
     - **frames** - `string[]`
-    
+
     You can see the already provided spinner [here](https://github.com/jcarpanelli/spinnies/blob/master/spinners.json).
   - **disableSpins** - `boolean`: Disable spins (will still print raw messages).
 
-*Note: If you are working in any `win32` platform, the default spin animation will be overriden. You can get rid of this defining a different spinner animation manually.*
+*Note: If you are working in any `win32` platform, the default spin animation will be overriden. You can get rid of this defining a different spinner animation manually, or by using the integrated VSCode terminal or Windows Terminal.*
 
-Example: 
+Example:
 
 ```js
 const spinner = { interval: 80, frames: ['🍇', '🍈', '🍉', '🍋'] }
@@ -132,7 +132,7 @@ Parameters:
 
 Return value: Returns the spinner's options.
 
-Example: 
+Example:
 
 ```js
 const spinnies = new Spinnies();

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.3] - 2019-06-123
+## Unreleased
 ### Changed
 - Use the Unicode dots animation when run inside a VSCode integrated terminal or Windows Terminal.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2019-06-123
+### Changed
+- Use the Unicode dots animation when run inside a VSCode integrated terminal or Windows Terminal.
+
 ## [0.4.2] - 2019-06-18
 ### Fixed
 - Fix line breaks when a custom succeedPrefix/failPrefix is provided

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class Spinnies {
       spinnerColor: 'greenBright',
       succeedColor: 'green',
       failColor: 'red',
-      spinner: !terminalSupportsUnicode() ? dashes : dots,
+      spinner: terminalSupportsUnicode() ? dots : dashes,
       disableSpins: false,
       ...options
     };

--- a/index.js
+++ b/index.js
@@ -5,17 +5,17 @@ const chalk = require('chalk');
 const cliCursor = require('cli-cursor');
 const { dashes, dots } = require('./spinners');
 
-const { purgeSpinnerOptions, purgeSpinnersOptions, colorOptions, breakText, getLinesLength } = require('./utils');
+const { purgeSpinnerOptions, purgeSpinnersOptions, colorOptions, breakText, getLinesLength, terminalSupportsUnicode } = require('./utils');
 const { isValidStatus, writeStream, cleanStream } = require('./utils');
 
 class Spinnies {
   constructor(options = {}) {
     options = purgeSpinnersOptions(options);
-    this.options = { 
+    this.options = {
       spinnerColor: 'greenBright',
       succeedColor: 'green',
       failColor: 'red',
-      spinner: process.platform === 'win32' ? dashes : dots,
+      spinner: !terminalSupportsUnicode() ? dashes : dots,
       disableSpins: false,
       ...options
     };

--- a/utils.js
+++ b/utils.js
@@ -47,7 +47,7 @@ function colorOptions({ color, succeedColor, failColor, spinnerColor }) {
 }
 
 function prefixOptions({ succeedPrefix, failPrefix }) {
-  if(terminalSupportUnicode()) {
+  if(terminalSupportsUnicode()) {
     succeedPrefix = succeedPrefix || '✓';
     failPrefix = failPrefix || '✖';
   } else {

--- a/utils.js
+++ b/utils.js
@@ -28,7 +28,7 @@ function purgeSpinnersOptions({ spinner, disableSpins, ...others }) {
 }
 
 function turnToValidSpinner(spinner = {}) {
-  const platformSpinner = !terminalSupportsUnicode() ? dashes : dots;
+  const platformSpinner = terminalSupportsUnicode() ? dots : dashes;
   if (!typeof spinner === 'object') return platformSpinner;
   let { interval, frames } = spinner;
   if (!Array.isArray(frames) || frames.length < 1) frames = platformSpinner.frames;

--- a/utils.js
+++ b/utils.js
@@ -47,8 +47,13 @@ function colorOptions({ color, succeedColor, failColor, spinnerColor }) {
 }
 
 function prefixOptions({ succeedPrefix, failPrefix }) {
-  succeedPrefix = succeedPrefix ? succeedPrefix : (!terminalSupportsUnicode() ? '√' : '✓');
-  failPrefix = failPrefix ? failPrefix : (!terminalSupportsUnicode() ?  '×' : '✖');
+  if(terminalSupportUnicode()) {
+    succeedPrefix = succeedPrefix || '✓';
+    failPrefix = failPrefix || '✖';
+  } else {
+    succeedPrefix = succeedPrefix || '√';
+    failPrefix = failPrefix || '×';
+  }
 
   return { succeedPrefix, failPrefix };
 }

--- a/utils.js
+++ b/utils.js
@@ -28,7 +28,7 @@ function purgeSpinnersOptions({ spinner, disableSpins, ...others }) {
 }
 
 function turnToValidSpinner(spinner = {}) {
-  const platformSpinner = process.platform === 'win32' ? dashes : dots;
+  const platformSpinner = !terminalSupportsUnicode() ? dashes : dots;
   if (!typeof spinner === 'object') return platformSpinner;
   let { interval, frames } = spinner;
   if (!Array.isArray(frames) || frames.length < 1) frames = platformSpinner.frames;
@@ -47,8 +47,8 @@ function colorOptions({ color, succeedColor, failColor, spinnerColor }) {
 }
 
 function prefixOptions({ succeedPrefix, failPrefix }) {
-  succeedPrefix = succeedPrefix ? succeedPrefix : (process.platform === 'win32' ? '√' : '✓');
-  failPrefix = failPrefix ? failPrefix : (process.platform === 'win32' ?  '×' : '✖');
+  succeedPrefix = succeedPrefix ? succeedPrefix : (!terminalSupportsUnicode() ? '√' : '✓');
+  failPrefix = failPrefix ? failPrefix : (!terminalSupportsUnicode() ?  '×' : '✖');
 
   return { succeedPrefix, failPrefix };
 }
@@ -90,6 +90,14 @@ function cleanStream(stream, rawLines) {
   readline.moveCursor(stream, 0, -rawLines.length);
 }
 
+function terminalSupportsUnicode() {
+    // The default command prompt and powershell in Windows do not support Unicode characters.
+    // However, the VSCode integrated terminal and the Windows Terminal both do.
+    return process.platform !== 'win32'
+      || process.env.TERM_PROGRAM === 'vscode'
+      || !!process.env.WT_SESSION
+}
+
 module.exports = {
   purgeSpinnersOptions,
   purgeSpinnerOptions,
@@ -98,4 +106,5 @@ module.exports = {
   getLinesLength,
   writeStream,
   cleanStream,
+  terminalSupportsUnicode,
 }


### PR DESCRIPTION
Both the inegrated terminal in VSCode, as well as the new Windows Terminal (currently in preview) support the Unicode characters used in the `dots` animation.

This change refactors the platform check to a separate function, and checks environment variables set by VSCode ( Microsoft/vscode#29426 ) and Windows Terminal ( Microsoft/Terminal#1040 )