### PR TITLE
Adds `continuous` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Parameters
     - **frames** - `string[]`
 
     You can see the already provided spinner [here](https://github.com/jcarpanelli/spinnies/blob/master/spinners.json).
-  - **disableSpins** - `boolean`: Disable spins (will still print raw messages).
+  - **disableSpins** - `boolean`: Disable spins (will still print raw messages). The default value is `false`.
+  - **continuous** - `boolean`: Run spinners indefinitely until process is terminated (useful for some development tools). The default value is `false`.
 
 *Note: If you are working in any `win32` platform, the default spin animation will be overriden. You can get rid of this defining a different spinner animation manually, or by using the integrated VSCode terminal or Windows Terminal.*
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ class Spinnies {
       failColor: 'red',
       spinner: terminalSupportsUnicode() ? dots : dashes,
       disableSpins: false,
+      continuous: false,
       ...options
     };
     this.spinners = {};
@@ -155,7 +156,7 @@ class Spinnies {
         output += `${line}\n`;
       });
 
-    if(!hasActiveSpinners) readline.clearScreenDown(this.stream);
+    if (!hasActiveSpinners) readline.clearScreenDown(this.stream);
     writeStream(this.stream, output, linesLength);
     if (hasActiveSpinners) cleanStream(this.stream, linesLength);
     this.lineCount = linesLength.length;
@@ -168,7 +169,7 @@ class Spinnies {
   }
 
   checkIfActiveSpinners() {
-    if (!this.hasActiveSpinners()) {
+    if (!this.hasActiveSpinners() && !this.options.continuous) {
       if (this.spin) {
         this.setStreamOutput();
         readline.moveCursor(this.stream, 0, this.lineCount);

--- a/utils.js
+++ b/utils.js
@@ -18,13 +18,14 @@ function purgeSpinnerOptions(options) {
   return { ...colors, ...opts };
 }
 
-function purgeSpinnersOptions({ spinner, disableSpins, ...others }) {
+function purgeSpinnersOptions({ spinner, continuous, disableSpins, ...others }) {
   const colors = colorOptions(others);
   const prefixes = prefixOptions(others);
+  const continuousOption = typeof continuous === 'boolean' ? { continuous } : {};
   const disableSpinsOption = typeof disableSpins === 'boolean' ? { disableSpins } : {};
   spinner = turnToValidSpinner(spinner);
 
-  return { ...colors, ...prefixes, ...disableSpinsOption, spinner }
+  return { ...colors, ...prefixes, ...continuousOption, ...disableSpinsOption, spinner }
 }
 
 function turnToValidSpinner(spinner = {}) {
@@ -47,7 +48,7 @@ function colorOptions({ color, succeedColor, failColor, spinnerColor }) {
 }
 
 function prefixOptions({ succeedPrefix, failPrefix }) {
-  if(terminalSupportsUnicode()) {
+  if (terminalSupportsUnicode()) {
     succeedPrefix = succeedPrefix || '✓';
     failPrefix = failPrefix || '✖';
   } else {
@@ -66,9 +67,9 @@ function breakText(text, prefixLength) {
 
 function breakLine(line, prefixLength) {
   const columns = process.stderr.columns || 95;
-  return line.length  >= columns - prefixLength
+  return line.length >= columns - prefixLength
     ? `${line.substring(0, columns - prefixLength - 1)}\n${
-      breakLine(line.substring(columns - prefixLength - 1, line.length), 0)
+    breakLine(line.substring(columns - prefixLength - 1, line.length), 0)
     }`
     : line;
 }
@@ -96,11 +97,11 @@ function cleanStream(stream, rawLines) {
 }
 
 function terminalSupportsUnicode() {
-    // The default command prompt and powershell in Windows do not support Unicode characters.
-    // However, the VSCode integrated terminal and the Windows Terminal both do.
-    return process.platform !== 'win32'
-      || process.env.TERM_PROGRAM === 'vscode'
-      || !!process.env.WT_SESSION
+  // The default command prompt and powershell in Windows do not support Unicode characters.
+  // However, the VSCode integrated terminal and the Windows Terminal both do.
+  return process.platform !== 'win32'
+    || process.env.TERM_PROGRAM === 'vscode'
+    || !!process.env.WT_SESSION
 }
 
 module.exports = {


### PR DESCRIPTION
First off, thank you for building spinnies! I've been looking for something exactly like this for a while.

Currently, once all spinners have either succeeded or failed, the spinners object is cleared and they can no longer be updated. I've added a `continuous` option to allow for the spinners to run and be updated indefinitely until the user manually terminates the process, as I am building a development tool and my use-case calls for it.