### PR TITLE
Fix typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ class Spinnies {
     if (this.spin) {
       clearInterval(this.currentInterval);
       this.currentInterval = this.loopStream();
-      if (!this.isCursonHidden) cliCursor.hide();
+      if (!this.isCursorHidden) cliCursor.hide();
       this.isCursorHidden = true;
       this.checkIfActiveSpinners();
     } else {


### PR DESCRIPTION
isCursonHidden -> isCursorHidden

Before this fix, `isCursonHidden` was undefined, so the condition was always true and `cliCursor.hide()` was called.

After the fix, when `isCursorHidden` is false, `cliCursor.hide()` is called.