### PR TITLE
Supports fullwidth characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "cli-cursor": "^3.0.0",
+    "string-width": "^4.2.0",
     "strip-ansi": "^5.2.0"
   },
   "devDependencies": {

--- a/utils.js
+++ b/utils.js
@@ -2,6 +2,7 @@
 
 const readline = require('readline');
 const stripAnsi = require('strip-ansi');
+const stringWidth = require('string-width');
 const { dashes, dots } = require('./spinners');
 
 const VALID_STATUSES = ['succeed', 'fail', 'spinning', 'non-spinnable', 'stopped'];
@@ -77,7 +78,7 @@ function breakLine(line, prefixLength) {
 function getLinesLength(text, prefixLength) {
   return stripAnsi(text)
     .split('\n')
-    .map((line, index) => index === 0 ? line.length + prefixLength : line.length);
+    .map((line, index) => index === 0 ? stringWidth(line) + prefixLength : stringWidth(line));
 }
 
 function writeStream(stream, output, rawLines) {


### PR DESCRIPTION
Thanks for making this library! I use it in my project.

If it is fullwidth characters , it will be missing. 

```:text.js
spinnies.add("fullwidth characters", {text: "一二三四五六七八九十"});
```

![image](https://user-images.githubusercontent.com/4888181/77163339-3231ab80-6af1-11ea-8f33-010977a5d064.png)

I corresponded using "string-width".

![image](https://user-images.githubusercontent.com/4888181/77163744-12e74e00-6af2-11ea-8cfd-d09e57bcf83e.png)

