### PR TITLE
Use file-extension in require()

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const readline = require('readline');
 const chalk = require('chalk');
 const cliCursor = require('cli-cursor');
-const { dashes, dots } = require('./spinners');
+const { dashes, dots } = require('./spinners.json');
 
 const { purgeSpinnerOptions, purgeSpinnersOptions, colorOptions, breakText, getLinesLength, terminalSupportsUnicode } = require('./utils');
 const { isValidStatus, writeStream, cleanStream } = require('./utils');

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,7 +3,7 @@
 const expect = require('chai').expect
 
 const { purgeSpinnersOptions, purgeSpinnerOptions, colorOptions, breakText } = require('../utils');
-const { dots } = require('../spinners');
+const { dots } = require('../spinners.json');
 
 describe('utils', () => {
   beforeEach('set options', () => {


### PR DESCRIPTION
When bundling with Rollup, the spinners from `spinners.json` cannot be resolved. Adding the `.json` extension to `require()?  fixes that.