### PR TITLE
Truffle improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # ![spin](https://i.ibb.co/4M0J13j/spin.png) Spinnies ![spin](https://i.ibb.co/4M0J13j/spin.png)
+> Maintained by the Truffle team, originally forked from
+> [jcarpanelli/spinnies](https://github.com/jcarpanelli/spinnies)
+
 > Node.js module to create and manage multiple spinners in command-line interface programs
 
-[![npm](https://img.shields.io/npm/v/spinnies.svg)](https://www.npmjs.com/package/spinnies)
-[![CircleCI](https://circleci.com/gh/jcarpanelli/spinnies.svg?style=shield)](https://circleci.com/gh/jcarpanelli/spinnies)
+
+[![npm](https://img.shields.io/npm/v/spinnies.svg)](https://www.npmjs.com/package/@trufflesuite/spinnies)
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg)](https://github.com/RichardLitt/standard-readme)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,204 @@
+// Attribution note:
+// These type declarations are modified from type declarations in
+// jcarpanelli/spinnies#25 by Adam Jarret <https://github.com/adamjarret>.
+
+export as namespace Spinnies;
+export = Spinnies;
+
+declare namespace Spinnies {
+    const dots: Spinner;
+    const dashes: Spinner;
+
+    type Color =
+      "black"
+      | "red"
+      | "green"
+      | "yellow"
+      | "blue"
+      | "magenta"
+      | "cyan"
+      | "white"
+      | "gray"
+      | "redBright"
+      | "greenBright"
+      | "yellowBright"
+      | "blueBright"
+      | "magentaBright"
+      | "cyanBright"
+      | "whiteBright";
+
+    type StopAllStatus = "succeed" | "fail" | "stopped";
+    type SpinnerStatus = StopAllStatus | "spinning" | "non-spinnable";
+
+    interface Spinner {
+        interval: number;
+        frames: string[];
+    }
+
+    /**
+     * The configuration for a given spinner
+     */
+    interface SpinnerOptions {
+        /**
+         * Text to show in the spinner. If none is provided, the name field will be shown.
+         */
+        text: string;
+
+        /**
+         * Indent the spinner with the given number of spaces.
+         */
+        indent: number;
+
+        /**
+         * Initial status of the spinner.
+         */
+        status: SpinnerStatus;
+
+        /**
+         * The color of the text that accompanies the spinner. If not specified, the console's default foreground color is used.
+         */
+        color?: Color;
+
+        /**
+         * The color for the text on success. Default value is `"green"`
+         */
+        succeedColor: Color;
+
+        /**
+         * The color for the text on failure. Default value is `"red"`.
+         */
+        failColor: Color;
+
+        /**
+         * The color of the spinner, when active. The default value is `"greenBright"`
+         */
+        spinnerColor: Color;
+    }
+
+    /**
+     * Contains top-level configuration for the Spinnies class. Also allows the
+     * caller to override default values used in `SpinnerOptions`.
+     */
+    interface Options {
+        /**
+         * The color of the text that accompanies the spinner. If not specified, the console's default foreground color is used.
+         */
+        color?: Color;
+
+        /**
+         * The color for the text on success. Default value is `"green"`
+         */
+        succeedColor: Color;
+
+        /**
+         * The color for the text on failure. Default value is `"red"`.
+         */
+        failColor: Color;
+
+        /**
+         * The color of the spinner, when active. The default value is `"greenBright"`
+         */
+        spinnerColor: Color;
+
+        /**
+         * The symbol to be used in place of the spinner on success. The default value is ✓.
+         */
+        succeedPrefix: string;
+
+        /**
+         * The symbol to be used in place of the spinner on failure. The default value is ✖.
+         */
+        failPrefix: string;
+
+        /**
+         * Disable spinner animations (will still print raw messages if `true`). The default value is `false`.
+         */
+        disableSpins: boolean;
+
+        /**
+         * Defines the animated spinner to be used while each spinner is active/spinning.
+         */
+        spinner: Spinner;
+    }
+}
+
+/**
+ * A class that manages multiple CLI spinners.
+ */
+declare class Spinnies {
+    /**
+     * The current configuration of this Spinnies object.
+     */
+    options: Spinnies.Options;
+
+    constructor(options?: Partial<Spinnies.Options>);
+
+    /**
+     * Add a new spinner with the given name.
+     *
+     * @returns full `SpinnerOptions` object for the given spinner, with
+     * defaults applied
+     */
+    add: (name: string, options?: Partial<Spinnies.SpinnerOptions>) => Spinnies.SpinnerOptions;
+
+    /**
+     * Get spinner by name.
+     *
+     * @returns full `SpinnerOptions` object for the given spinner, with
+     * defaults applied
+     */
+    pick: (name: string) => Spinnies.SpinnerOptions;
+
+    /**
+     * Remove spinner with name.
+     *
+     * @returns full `SpinnerOptions` object for the given spinner, with
+     * defaults applied
+     */
+    remove: (name: string) => Spinnies.SpinnerOptions;
+
+    /**
+     * Updates the spinner with name name with the provided options. Retains
+     * the value of options that aren't specified.
+     *
+     * @returns full `SpinnerOptions` object for the given spinner, with
+     * defaults applied
+     */
+    update: (name: string, options?: Partial<Spinnies.SpinnerOptions>) => Spinnies.SpinnerOptions;
+
+    /**
+     * Sets the specified spinner status as succeed.
+     *
+     * @returns full `SpinnerOptions` object for the given spinner, with
+     * defaults applied
+     */
+    succeed: (name: string, options?: Partial<Spinnies.SpinnerOptions>) => Spinnies.SpinnerOptions;
+
+    /**
+     * Sets the specified spinner status as fail.
+     *
+     * @returns full `SpinnerOptions` object for the given spinner, with
+     * defaults applied
+     */
+    fail: (name: string, options?: Partial<Spinnies.SpinnerOptions>) => Spinnies.SpinnerOptions;
+
+    /**
+     * Stops the spinners and sets the non-succeeded and non-failed ones to the provided status.
+     *
+     * @returns an object that maps spinner names to final `SpinnerOptions` objects for each spinner, with
+     * defaults applied
+     */
+    stopAll: (status?: Spinnies.StopAllStatus) => { [name: string]: Spinnies.SpinnerOptions };
+
+    /**
+     * @returns false if all spinners have succeeded, failed or have been stopped
+     */
+    hasActiveSpinners: () => boolean;
+
+    /**
+     * Disables the spinner loop after all spinners have deactivated. Must be
+     * called after calling `remove` on the final spinner, otherwise the
+     * spinner loop will prevent the process from exiting.
+     */
+    checkIfActiveSpinners: () => void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare namespace Spinnies {
     const dashes: Spinner;
 
     type Color =
-      "black"
+        "black"
       | "red"
       | "green"
       | "yellow"
@@ -25,7 +25,8 @@ declare namespace Spinnies {
       | "blueBright"
       | "magentaBright"
       | "cyanBright"
-      | "whiteBright";
+      | "whiteBright"
+      | "none";
 
     type StopAllStatus = "succeed" | "fail" | "stopped";
     type SpinnerStatus = StopAllStatus | "spinning" | "non-spinnable";
@@ -55,50 +56,15 @@ declare namespace Spinnies {
         status: SpinnerStatus;
 
         /**
-         * The color of the text that accompanies the spinner. If not specified, the console's default foreground color is used.
+         * The color of the text that accompanies the spinner. Default value is
+         * `"none"`.
          */
-        color?: Color;
+        textColor?: Color;
 
         /**
-         * The color for the text on success. Default value is `"green"`
+         * The color of the spinner or prefix. Default value is `"none"`.
          */
-        succeedColor: Color;
-
-        /**
-         * The color for the text on failure. Default value is `"red"`.
-         */
-        failColor: Color;
-
-        /**
-         * The color of the spinner, when active. The default value is `"greenBright"`
-         */
-        spinnerColor: Color;
-    }
-
-    /**
-     * Contains top-level configuration for the Spinnies class. Also allows the
-     * caller to override default values used in `SpinnerOptions`.
-     */
-    interface Options {
-        /**
-         * The color of the text that accompanies the spinner. If not specified, the console's default foreground color is used.
-         */
-        color?: Color;
-
-        /**
-         * The color for the text on success. Default value is `"green"`
-         */
-        succeedColor: Color;
-
-        /**
-         * The color for the text on failure. Default value is `"red"`.
-         */
-        failColor: Color;
-
-        /**
-         * The color of the spinner, when active. The default value is `"greenBright"`
-         */
-        spinnerColor: Color;
+        prefixColor?: Color;
 
         /**
          * The symbol to be used in place of the spinner on success. The default value is ✓.
@@ -111,6 +77,43 @@ declare namespace Spinnies {
         failPrefix: string;
 
         /**
+         * The symbol to be used in place of the spinner on stop. Default value is `""`.
+         */
+        stoppedPrefix?: string;
+    }
+
+    /**
+     * Contains top-level configuration for the Spinnies class. Also allows the
+     * caller to override default values used in `SpinnerOptions`.
+     */
+    interface Options {
+        /**
+         * The color of the text that accompanies the spinner. Default value is
+         * `"none"`.
+         */
+        textColor?: Color;
+
+        /**
+         * The color of the spinner. Default value is `"none"`.
+         */
+        prefixColor?: Color;
+
+        /**
+         * The symbol to be used in place of the spinner on success. The default value is ✓.
+         */
+        succeedPrefix: string;
+
+        /**
+         * The symbol to be used in place of the spinner on failure. The default value is ✖.
+         */
+        failPrefix: string;
+
+        /**
+         * The symbol to be used in place of the spinner on stop. Default value is `undefined`.
+         */
+        stoppedPrefix?: string;
+
+        /**
          * Disable spinner animations (will still print raw messages if `true`). The default value is `false`.
          */
         disableSpins: boolean;
@@ -119,6 +122,7 @@ declare namespace Spinnies {
          * Defines the animated spinner to be used while each spinner is active/spinning.
          */
         spinner: Spinner;
+
     }
 }
 
@@ -172,6 +176,7 @@ declare class Spinnies {
      * @returns full `SpinnerOptions` object for the given spinner, with
      * defaults applied
      */
+    succeed: (name: string, text?: string) => Spinnies.SpinnerOptions;
     succeed: (name: string, options?: Partial<Spinnies.SpinnerOptions>) => Spinnies.SpinnerOptions;
 
     /**
@@ -180,7 +185,17 @@ declare class Spinnies {
      * @returns full `SpinnerOptions` object for the given spinner, with
      * defaults applied
      */
+    fail: (name: string, text?: string) => Spinnies.SpinnerOptions;
     fail: (name: string, options?: Partial<Spinnies.SpinnerOptions>) => Spinnies.SpinnerOptions;
+
+    /**
+     * Sets the specified spinner status as stopped.
+     *
+     * @returns full `SpinnerOptions` object for the given spinner, with
+     * defaults applied
+     */
+    stop: (name: string, text?: string) => Spinnies.SpinnerOptions;
+    stop: (name: string, options?: Partial<Spinnies.SpinnerOptions>) => Spinnies.SpinnerOptions;
 
     /**
      * Stops the spinners and sets the non-succeeded and non-failed ones to the provided status.

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ declare namespace Spinnies {
       | "whiteBright"
       | "none";
 
-    type StopAllStatus = "succeed" | "fail" | "stopped";
+    type StopAllStatus = "succeed" | "fail" | "warn" | "stopped";
     type SpinnerStatus = StopAllStatus | "spinning" | "non-spinnable";
 
     interface Spinner {
@@ -75,6 +75,11 @@ declare namespace Spinnies {
          * The symbol to be used in place of the spinner on failure. The default value is ✖.
          */
         failPrefix: string;
+
+        /**
+         * The symbol to be used in place of the spinner on warn. The default value is ⚠.
+         */
+        warnPrefix: string;
 
         /**
          * The symbol to be used in place of the spinner on stop. Default value is `""`.
@@ -181,6 +186,15 @@ declare class Spinnies {
 
     /**
      * Sets the specified spinner status as fail.
+     *
+     * @returns full `SpinnerOptions` object for the given spinner, with
+     * defaults applied
+     */
+    fail: (name: string, text?: string) => Spinnies.SpinnerOptions;
+    fail: (name: string, options?: Partial<Spinnies.SpinnerOptions>) => Spinnies.SpinnerOptions;
+
+    /**
+     * Sets the specified spinner status as warn.
      *
      * @returns full `SpinnerOptions` object for the given spinner, with
      * defaults applied

--- a/index.js
+++ b/index.js
@@ -1,20 +1,18 @@
 'use strict';
 
 const readline = require('readline');
-const chalk = require('chalk');
 const cliCursor = require('cli-cursor');
 const { dashes, dots } = require('./spinners');
 
-const { purgeSpinnerOptions, purgeSpinnersOptions, colorOptions, breakText, getLinesLength, terminalSupportsUnicode } = require('./utils');
+const { purgeSpinnerOptions, purgeSpinnersOptions, colorOptions, prefixOptions, breakText, getLinesLength, terminalSupportsUnicode, applyColor } = require('./utils');
 const { isValidStatus, writeStream, cleanStream } = require('./utils');
 
 class Spinnies {
   constructor(options = {}) {
     options = purgeSpinnersOptions(options);
     this.options = {
-      spinnerColor: 'greenBright',
-      succeedColor: 'green',
-      failColor: 'red',
+      prefixColor: 'none',
+      textColor: 'none',
       spinner: terminalSupportsUnicode() ? dots : dashes,
       disableSpins: false,
       ...options
@@ -34,12 +32,21 @@ class Spinnies {
   }
 
   add(name, options = {}) {
-    if (typeof name !== 'string') throw Error('A spinner reference name must be specified');
-    if (!options.text) options.text = name;
+    if (typeof name !== 'string') {
+      throw Error('A spinner reference name must be specified');
+    }
+
+    if (typeof options === "string") {
+      options = { text: options };
+    }
+
+    if (!options.text) {
+      options.text = name;
+    }
+
     const spinnerProperties = {
       ...colorOptions(this.options),
-      succeedPrefix: this.options.succeedPrefix,
-      failPrefix: this.options.failPrefix,
+      ...prefixOptions(this.options),
       status: 'spinning',
       ...purgeSpinnerOptions(options),
     };
@@ -59,6 +66,13 @@ class Spinnies {
   }
 
   succeed(name, options = {}) {
+    if (typeof options === "string") {
+      options = {
+        text: options,
+        prefixColor: "green",
+        textColor: "none"
+      }
+    }
     this.setSpinnerProperties(name, options, 'succeed');
     this.updateSpinnerState();
 
@@ -66,11 +80,35 @@ class Spinnies {
   }
 
   fail(name, options = {}) {
+    if (typeof options === "string") {
+      options = {
+        text: options,
+        prefixColor: "red",
+        textColor: "none"
+      }
+    }
+
     this.setSpinnerProperties(name, options, 'fail');
     this.updateSpinnerState();
 
     return this.spinners[name];
   }
+
+  stop(name, options = {}) {
+    if (typeof options === "string") {
+      options = {
+        text: options,
+        prefixColor: "red",
+        textColor: "none"
+      }
+    }
+
+    this.setSpinnerProperties(name, options, 'stopped');
+    this.updateSpinnerState();
+
+    return this.spinners[name];
+  }
+
 
   remove(name) {
     if (typeof name !== 'string') throw Error('A spinner reference name must be specified');
@@ -83,14 +121,27 @@ class Spinnies {
   stopAll(newStatus = 'stopped') {
     Object.keys(this.spinners).forEach(name => {
       const { status: currentStatus } = this.spinners[name];
-      if (currentStatus !== 'fail' && currentStatus !== 'succeed' && currentStatus !== 'non-spinnable') {
-        if (newStatus === 'succeed' || newStatus === 'fail') {
-          this.spinners[name].status = newStatus;
-          this.spinners[name].color = this.options[`${newStatus}Color`];
-        } else {
-          this.spinners[name].status = 'stopped';
-          this.spinners[name].color = 'grey';
+      const options = this.spinners[name];
+
+      if (!['fail', 'succeed', 'non-spinnable'].includes(currentStatus)) {
+        if (!['succeed', 'fail'].includes(newStatus)) {
+          newStatus = 'stopped';
         }
+
+        switch(newStatus) {
+          case 'fail':
+            options.prefixColor = 'red';
+            options.textColor = 'none';
+            break;
+          case 'succeed':
+            options.prefixColor = 'green';
+            options.textColor = 'none';
+            break;
+          default:
+            options.textColor = 'none';
+        }
+
+        options.status = newStatus;
       }
     });
     this.checkIfActiveSpinners();
@@ -137,29 +188,39 @@ class Spinnies {
     const hasActiveSpinners = this.hasActiveSpinners();
     Object
       .values(this.spinners)
-      .map(({ text, status, color, spinnerColor, succeedColor, failColor, succeedPrefix, failPrefix, indent }) => {
+      .map(({ text, status, textColor, prefixColor, succeedPrefix, failPrefix, stoppedPrefix, indent }) => {
         let line;
         let prefixLength = indent || 0;
-        if (status === 'spinning') {
-          prefixLength += frame.length + 1;
-          text = breakText(text, prefixLength);
-          line = `${chalk[spinnerColor](frame)} ${color ? chalk[color](text) : text}`;
-        } else {
-          if (status === 'succeed') {
+
+        let prefix = '';
+
+        switch(status) {
+          case 'spinning':
+            prefixLength += frame.length + 1;
+            prefix = `${frame} `
+            break;
+          case 'succeed':
             prefixLength += succeedPrefix.length + 1;
-            if (hasActiveSpinners) text = breakText(text, prefixLength);
-            line = `${chalk.green(succeedPrefix)} ${chalk[succeedColor](text)}`;
-          } else if (status === 'fail') {
+            prefix = `${succeedPrefix} `;
+            break;
+          case 'fail':
             prefixLength += failPrefix.length + 1;
-            if (hasActiveSpinners) text = breakText(text, prefixLength);
-            line = `${chalk.red(failPrefix)} ${chalk[failColor](text)}`;
-          } else {
-            if (hasActiveSpinners) text = breakText(text, prefixLength);
-            line = color ? chalk[color](text) : text;
-          }
+            prefix = `${failPrefix} `;
+            break;
+          default:
+            prefixLength += stoppedPrefix ? stoppedPrefix.length + 1 : 0;
+            prefix = stoppedPrefix ? `${stoppedPrefix} ` : "";
+            break;
         }
+
+        if (status === 'spinning' || hasActiveSpinners) {
+          text = breakText(text, prefixLength);
+        }
+
+        line = `${applyColor(prefixColor, prefix)}${applyColor(textColor, text)}`
+
         linesLength.push(...getLinesLength(text, prefixLength));
-        output += indent ? `${" ".repeat(indent)}${line}\n` : `${line}\n`;
+        output += indent ? `${' '.repeat(indent)}${line}\n` : `${line}\n`;
       });
 
     if(!hasActiveSpinners) readline.clearScreenDown(this.stream);
@@ -195,6 +256,7 @@ class Spinnies {
       process.exit(0);
     });
   }
+
 }
 
 module.exports = Spinnies;

--- a/index.js
+++ b/index.js
@@ -144,8 +144,6 @@ class Spinnies {
         options.status = newStatus;
       }
     });
-    this.checkIfActiveSpinners();
-
     return this.spinners;
   }
 
@@ -168,7 +166,6 @@ class Spinnies {
       this.currentInterval = this.loopStream();
       if (!this.isCursorHidden) cliCursor.hide();
       this.isCursorHidden = true;
-      this.checkIfActiveSpinners();
     } else {
       this.setRawStreamOutput();
     }
@@ -179,6 +176,7 @@ class Spinnies {
     return setInterval(() => {
       this.setStreamOutput(frames[this.currentFrameIndex]);
       this.currentFrameIndex = this.currentFrameIndex === frames.length - 1 ? 0 : ++this.currentFrameIndex
+      this.checkIfActiveSpinners();
     }, interval);
   }
 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ class Spinnies {
     return this.spinners[name];
   }
 
-  succeed(name, options = {}) {
+  succeed(name, options) {
     if (typeof options === "string") {
       options = {
         text: options,
@@ -73,13 +73,21 @@ class Spinnies {
         textColor: "none"
       }
     }
+
+    if (!options) {
+      options = {
+        prefixColor: "green",
+        textColor: "none"
+      };
+    }
+
     this.setSpinnerProperties(name, options, 'succeed');
     this.updateSpinnerState();
 
     return this.spinners[name];
   }
 
-  fail(name, options = {}) {
+  fail(name, options) {
     if (typeof options === "string") {
       options = {
         text: options,
@@ -88,7 +96,36 @@ class Spinnies {
       }
     }
 
+    if (!options) {
+      options = {
+        prefixColor: "red",
+        textColor: "none"
+      };
+    }
+
     this.setSpinnerProperties(name, options, 'fail');
+    this.updateSpinnerState();
+
+    return this.spinners[name];
+  }
+
+  warn(name, options) {
+    if (typeof options === "string") {
+      options = {
+        text: options,
+        prefixColor: "yellow",
+        textColor: "none"
+      }
+    }
+
+    if (!options) {
+      options = {
+        prefixColor: "yellow",
+        textColor: "none"
+      };
+    }
+
+    this.setSpinnerProperties(name, options, 'warn');
     this.updateSpinnerState();
 
     return this.spinners[name];
@@ -123,8 +160,8 @@ class Spinnies {
       const { status: currentStatus } = this.spinners[name];
       const options = this.spinners[name];
 
-      if (!['fail', 'succeed', 'non-spinnable'].includes(currentStatus)) {
-        if (!['succeed', 'fail'].includes(newStatus)) {
+      if (!['fail', 'succeed', 'warn', 'non-spinnable'].includes(currentStatus)) {
+        if (!['succeed', 'fail', 'warn'].includes(newStatus)) {
           newStatus = 'stopped';
         }
 
@@ -135,6 +172,10 @@ class Spinnies {
             break;
           case 'succeed':
             options.prefixColor = 'green';
+            options.textColor = 'none';
+            break;
+          case 'warn':
+            options.prefixColor = 'yellow';
             options.textColor = 'none';
             break;
           default:
@@ -186,7 +227,7 @@ class Spinnies {
     const hasActiveSpinners = this.hasActiveSpinners();
     Object
       .values(this.spinners)
-      .map(({ text, status, textColor, prefixColor, succeedPrefix, failPrefix, stoppedPrefix, indent }) => {
+      .map(({ text, status, textColor, prefixColor, succeedPrefix, failPrefix, warnPrefix, stoppedPrefix, indent }) => {
         let line;
         let prefixLength = indent || 0;
 
@@ -204,6 +245,10 @@ class Spinnies {
           case 'fail':
             prefixLength += failPrefix.length + 1;
             prefix = `${failPrefix} `;
+            break;
+          case 'warn':
+            prefixLength += warnPrefix.length + 1;
+            prefix = `${warnPrefix} `;
             break;
           default:
             prefixLength += stoppedPrefix ? stoppedPrefix.length + 1 : 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "spinnies",
-  "version": "0.5.1",
+  "name": "@trufflesuite/spinnies",
+  "version": "0.1.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "npx mocha test"
   },
+  "types": "index.d.ts",
   "keywords": [
     "node",
     "nodejs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "spinnies",
-  "version": "0.5.1",
+  "name": "@trufflesuite/spinnies",
+  "version": "0.1.0-0",
   "description": "Create and manage multiple spinners in command-line interface programs",
   "main": "index.js",
   "scripts": {
@@ -24,15 +24,25 @@
     "command",
     "terminal"
   ],
-  "author": "Juan Bautista Carpanelli <juanbanelli@gmail.com>",
+  "contributors": [
+    {
+      "name": "Juan Bautista Carpanelli",
+      "email": "juanbanelli@gmail.com",
+      "url": "https://github.com/jcarpanelli"
+    },
+    {
+      "name": "Ben Burns",
+      "url": "https://github.com/benjamincburns"
+    }
+  ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:jcarpanelli/spinnies.git"
+    "url": "git+ssh://git@github.com:trufflesuite/spinnies.git"
   },
   "bugs": {
-    "url": "https://github.com/jcarpanelli/spinnies/issues"
+    "url": "https://github.com/trufflesuite/spinnies/issues"
   },
-  "homepage": "https://github.com/jcarpanelli/spinnies#readme",
+  "homepage": "https://github.com/trufflesuite/spinnies#readme",
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.4.2",

--- a/test/behaviours.test.js
+++ b/test/behaviours.test.js
@@ -7,6 +7,7 @@ function expectToBehaveLikeAnUpdate(self, status) {
     update: "spinning",
     stop: "stopped",
     succeed: "succeed",
+    warn: "warn",
     fail: "fail"
   };
   const currentStatus = statusMap[status] || status;

--- a/test/behaviours.test.js
+++ b/test/behaviours.test.js
@@ -3,11 +3,18 @@
 const expect = require('chai').expect
 
 function expectToBehaveLikeAnUpdate(self, status) {
-  const currentStatus = status === 'update' ? 'succeed' : status;
+  const statusMap = {
+    update: "spinning",
+    stop: "stopped",
+    succeed: "succeed",
+    fail: "fail"
+  };
+  const currentStatus = statusMap[status] || status;
 
   describe(`#${status}`, () => {
+
     it(`changes the status to ${currentStatus}`, () => {
-      const spinner = self.spinnies[currentStatus]('spinner');
+      const spinner = self.spinnies[status]('spinner');
       const anotherSpinner = self.spinnies.pick('another-spinner');
       expect(spinner.status).to.eq(currentStatus);
       expect(anotherSpinner.status).to.eq('spinning');
@@ -28,7 +35,7 @@ function expectToBehaveLikeAnUpdate(self, status) {
     context('when specifying options', () => {
       context('when options are correct', () => {
         it('overrides the default options', () => {
-          const options = { text: 'updated text', color: 'black', spinnerColor: 'black' };
+          const options = { text: 'updated text', textColor: 'black', prefixColor: 'black' };
           const spinner = self.spinnies[status]('spinner', options);
           expect(spinner).to.include(options);
         });
@@ -36,15 +43,15 @@ function expectToBehaveLikeAnUpdate(self, status) {
 
       context('when options have no valid values', () => {
         it('mantains the previous options', () => {
-          const options = { text: 42, color: 'foo', spinnerColor: 'bar' };
-          const spinner = self.spinnies[currentStatus]('spinner', options);
-          expect(spinner).to.include({ text: 'spinner', spinnerColor: 'greenBright' });
+          const options = { text: 42, textColor: 'foo', prefixColor: 'bar' };
+          const spinner = self.spinnies[status]('spinner', options);
+          expect(spinner).to.include({ text: 'spinner' });
         });
       });
 
       context('when specifying invalid attributes', () => {
         it('ignores those attributes', () => {
-          const options = { text: 'updated text', color: 'black', spinnerColor: 'black' };
+          const options = { text: 'updated text', textColor: 'black', prefixColor: 'black' };
           const invalidOptions = { foo: 42, bar: 'bar'}
           const spinner = self.spinnies[status]('spinner', options);
           expect(spinner).to.include(options);

--- a/test/spinners.test.js
+++ b/test/spinners.test.js
@@ -97,6 +97,7 @@ describe('Spinnies', () => {
       expectToBehaveLikeAnUpdate(this, 'succeed');
       expectToBehaveLikeAnUpdate(this, 'fail');
       expectToBehaveLikeAnUpdate(this, 'stop');
+      expectToBehaveLikeAnUpdate(this, 'warn');
       expectToBehaveLikeAnUpdate(this, 'update');
 
       describe('#stopAll', () => {

--- a/test/spinners.test.js
+++ b/test/spinners.test.js
@@ -13,9 +13,6 @@ describe('Spinnies', () => {
   beforeEach('constructor', () => {
     this.spinnies = new Spinnies();
     this.spinnersOptions = {
-      succeedColor: 'green',
-      failColor: 'red',
-      spinnerColor: 'greenBright',
       status: 'spinning',
     };
   });
@@ -53,7 +50,7 @@ describe('Spinnies', () => {
         context('when specifying options', () => {
           context('when options are correct', () => {
             it('overrides the default options', () => {
-              const options = { color: 'black', spinnerColor: 'black', succeedColor: 'black', failColor: 'black', status: 'non-spinnable', indent: 2 };
+              const options = { textColor: 'black', prefixColor: 'black', status: 'non-spinnable', indent: 2 };
               const spinner = this.spinnies.add('spinner-name', options);
               expect(spinner).to.include({ ...this.spinnersOptions, ...options });
             });
@@ -61,7 +58,7 @@ describe('Spinnies', () => {
 
           context('when options are not valid', () => {
             it('mantains the default options', () => {
-              const options = { color: 'foo', spinnerColor: 'bar', status: 'buz', indent: 'baz' };
+              const options = { textColor: 'foo', prefixColor: 'bar', status: 'buz', indent: 'baz' };
               const spinner = this.spinnies.add('spinner-name', options);
               expect(spinner).to.include(this.spinnersOptions);
             });
@@ -99,6 +96,7 @@ describe('Spinnies', () => {
 
       expectToBehaveLikeAnUpdate(this, 'succeed');
       expectToBehaveLikeAnUpdate(this, 'fail');
+      expectToBehaveLikeAnUpdate(this, 'stop');
       expectToBehaveLikeAnUpdate(this, 'update');
 
       describe('#stopAll', () => {
@@ -121,7 +119,8 @@ describe('Spinnies', () => {
 
             expectToKeepFinishedSpinners();
             expect(this.thirdSpinner.status).to.eq('succeed');
-            expect(this.thirdSpinner.color).to.eq('green');
+            expect(this.thirdSpinner.prefixColor).to.eq('green');
+            expect(this.thirdSpinner.textColor).to.eq('none');
           });
 
           it('sets non-finished spinners as fail', () => {
@@ -129,7 +128,8 @@ describe('Spinnies', () => {
 
             expectToKeepFinishedSpinners();
             expect(this.thirdSpinner.status).to.eq('fail');
-            expect(this.thirdSpinner.color).to.eq('red');
+            expect(this.thirdSpinner.prefixColor).to.eq('red');
+            expect(this.thirdSpinner.textColor).to.eq('none');
           });
 
           it('sets non-finished spinners as stopped', () => {
@@ -137,7 +137,8 @@ describe('Spinnies', () => {
 
             expectToKeepFinishedSpinners();
             expect(this.thirdSpinner.status).to.eq('stopped');
-            expect(this.thirdSpinner.color).to.eq('grey');
+            expect(this.thirdSpinner.prefixColor).to.eq('none');
+            expect(this.thirdSpinner.textColor).to.eq('none');
           });
         });
 
@@ -147,7 +148,8 @@ describe('Spinnies', () => {
 
             expectToKeepFinishedSpinners();
             expect(this.thirdSpinner.status).to.eq('stopped');
-            expect(this.thirdSpinner.color).to.eq('grey');
+            expect(this.thirdSpinner.prefixColor).to.eq('none');
+            expect(this.thirdSpinner.textColor).to.eq('none');
           });
         });
       });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const expect = require('chai').expect
+const chalk = require('chalk');
 
-const { purgeSpinnersOptions, purgeSpinnerOptions, colorOptions, breakText } = require('../utils');
+const { purgeSpinnersOptions, purgeSpinnerOptions, colorOptions, breakText, applyColor } = require('../utils');
 const { dots } = require('../spinners');
 
 describe('utils', () => {
   beforeEach('set options', () => {
-    this.colors = { color: 'blue', spinnerColor: 'blue', succeedColor: 'blue', failColor: 'blue' };
+    this.colors = { textColor: 'blue', prefixColor: 'blue' };
   });
 
   describe('functions', () => {
@@ -21,9 +22,9 @@ describe('utils', () => {
         });
 
         it('removes invalid colors', () => {
-          const colors = colorOptions({ ...this.colors, spinnerColor: 'foo', succeedColor: 'bar' });
-          expect(colors).to.include({ color: 'blue', failColor: 'blue' });
-          expect(colors).to.not.have.any.keys('spinnerColor', 'succeedColor');
+          const colors = colorOptions({ ...this.colors, prefixColor: 'foo' });
+          expect(colors).to.include({ textColor: 'blue' });
+          expect(colors).to.not.have.any.keys('prefixColor');
         });
       });
     });
@@ -120,6 +121,42 @@ describe('utils', () => {
         it('does not add line-breaks to the given text', () => {
           const text = '12345';
           expect(text.split('\n')).to.have.lengthOf(1);
+        });
+      });
+    });
+
+    describe('#applyColor', () => {
+      context('when a valid color is given', () => {
+        it ('should apply a color', () => {
+          const text = '12345';
+          const color = 'green';
+
+          const coloredText = applyColor(color, text);
+
+          expect(coloredText).to.equal(chalk.green(text));
+          expect(coloredText).not.to.equal(text);
+        });
+      });
+
+      context("when a color value of 'none' is given", () => {
+        it ('should not apply a color', () => {
+          const text = '12345';
+          const color = 'none';
+
+          const coloredText = applyColor(color, text);
+
+          expect(coloredText).to.equal(text);
+        });
+      });
+
+      context('when a color value of undefined is given', () => {
+        it ('should not apply a color', () => {
+          const text = '12345';
+          const color = undefined;
+
+          const coloredText = applyColor(color, text);
+
+          expect(coloredText).to.equal(text);
         });
       });
     });

--- a/utils.js
+++ b/utils.js
@@ -3,20 +3,22 @@
 const readline = require('readline');
 const stripAnsi = require('strip-ansi');
 const { dashes, dots } = require('./spinners');
+const chalk = require('chalk');
 
 const VALID_STATUSES = ['succeed', 'fail', 'spinning', 'non-spinnable', 'stopped'];
-const VALID_COLORS = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'gray', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', 'cyanBright', 'whiteBright'];
+const VALID_COLORS = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'gray', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', 'cyanBright', 'whiteBright', 'none'];
 
 function purgeSpinnerOptions(options) {
   const { text, status, indent } = options;
   const opts = { text, status, indent };
   const colors = colorOptions(options);
+  const prefixes = prefixOptions(options);
 
   if (!VALID_STATUSES.includes(status)) delete opts.status;
   if (typeof text !== 'string') delete opts.text;
   if (typeof indent !== 'number') delete opts.indent;
 
-  return { ...colors, ...opts };
+  return { ...colors, ...prefixes, ...opts};
 }
 
 function purgeSpinnersOptions({ spinner, disableSpins, ...others }) {
@@ -38,8 +40,8 @@ function turnToValidSpinner(spinner = {}) {
   return { interval, frames };
 }
 
-function colorOptions({ color, succeedColor, failColor, spinnerColor }) {
-  const colors = { color, succeedColor, failColor, spinnerColor };
+function colorOptions({ textColor, prefixColor }) {
+  const colors = { textColor, prefixColor };
   Object.keys(colors).forEach(key => {
     if (!VALID_COLORS.includes(colors[key])) delete colors[key];
   });
@@ -47,7 +49,7 @@ function colorOptions({ color, succeedColor, failColor, spinnerColor }) {
   return colors;
 }
 
-function prefixOptions({ succeedPrefix, failPrefix }) {
+function prefixOptions({ succeedPrefix, failPrefix, stoppedPrefix }) {
   if(terminalSupportsUnicode()) {
     succeedPrefix = succeedPrefix || '✓';
     failPrefix = failPrefix || '✖';
@@ -56,7 +58,9 @@ function prefixOptions({ succeedPrefix, failPrefix }) {
     failPrefix = failPrefix || '×';
   }
 
-  return { succeedPrefix, failPrefix };
+  stoppedPrefix = stoppedPrefix || "";
+
+  return { succeedPrefix, failPrefix, stoppedPrefix };
 }
 
 function breakText(text, prefixLength) {
@@ -104,13 +108,23 @@ function terminalSupportsUnicode() {
       || !!process.env.WT_SESSION
 }
 
+function applyColor(color, text) {
+  if (color && color !== 'none') {
+    return chalk[color](text);
+  }
+
+  return text;
+}
+
 module.exports = {
   purgeSpinnersOptions,
   purgeSpinnerOptions,
   colorOptions,
+  prefixOptions,
   breakText,
   getLinesLength,
   writeStream,
   cleanStream,
   terminalSupportsUnicode,
+  applyColor
 }

--- a/utils.js
+++ b/utils.js
@@ -5,7 +5,7 @@ const stripAnsi = require('strip-ansi');
 const { dashes, dots } = require('./spinners');
 const chalk = require('chalk');
 
-const VALID_STATUSES = ['succeed', 'fail', 'spinning', 'non-spinnable', 'stopped'];
+const VALID_STATUSES = ['succeed', 'fail', 'warn', 'spinning', 'non-spinnable', 'stopped'];
 const VALID_COLORS = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'gray', 'redBright', 'greenBright', 'yellowBright', 'blueBright', 'magentaBright', 'cyanBright', 'whiteBright', 'none'];
 
 function purgeSpinnerOptions(options) {
@@ -49,18 +49,20 @@ function colorOptions({ textColor, prefixColor }) {
   return colors;
 }
 
-function prefixOptions({ succeedPrefix, failPrefix, stoppedPrefix }) {
+function prefixOptions({ succeedPrefix, failPrefix, warnPrefix, stoppedPrefix }) {
   if(terminalSupportsUnicode()) {
     succeedPrefix = succeedPrefix || '✓';
     failPrefix = failPrefix || '✖';
+    warnPrefix = warnPrefix || '⚠';
   } else {
     succeedPrefix = succeedPrefix || '√';
     failPrefix = failPrefix || '×';
+    warnPrefix = warnPrefix || '~';
   }
 
   stoppedPrefix = stoppedPrefix || "";
 
-  return { succeedPrefix, failPrefix, stoppedPrefix };
+  return { succeedPrefix, failPrefix, warnPrefix, stoppedPrefix };
 }
 
 function breakText(text, prefixLength) {


### PR DESCRIPTION
- [x] make it possible to explicitly set text, spinner, and prefix color regardless of spinner state
- [x] make text color default to terminal default for all states
- [x] make spinner color default to terminal default when active
- [x] add an explicit stop method
- [x] fix jcarpanelli/spinnies#34
- [x] add an explicit `warn` method